### PR TITLE
Use CDN url for get-pip.py

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,7 +9,7 @@
   register: pip_is_installed
 
 - name: download pip
-  get_url: url=https://raw.github.com/pypa/pip/master/contrib/get-pip.py dest={{ pip_download_dest }}
+  get_url: url=https://bootstrap.pypa.io/get-pip.py dest={{ pip_download_dest }}
   when: pip_is_installed.rc != 0
 
 - name: install pip


### PR DESCRIPTION
Hi @bobbyrenwick 

Thanks for the last merge! Here is one more.

URL for `get-pip.py` on https://pip.pypa.io/en/latest/installing.html#install-pip now points to `https://bootstrap.pypa.io/get-pip.py`. This is provided by Fastly's CDN so it makes sense to change it in the role too according to current docs.

```
$ dig bootstrap.pypa.io

; <<>> DiG 9.8.3-P1 <<>> bootstrap.pypa.io
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 44232
;; flags: qr rd ra; QUERY: 1, ANSWER: 2, AUTHORITY: 0, ADDITIONAL: 0

;; QUESTION SECTION:
;bootstrap.pypa.io.		IN	A

;; ANSWER SECTION:
bootstrap.pypa.io.	15290	IN	CNAME	c.global-ssl.fastly.net.
c.global-ssl.fastly.net. 29	IN	A	23.235.43.175
```