### PR TITLE
Removes extra "changed_when" task parameter

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,7 +7,6 @@
   ignore_errors: true
   changed_when: false
   register: pip_is_installed
-  changed_when: false
 
 - name: Download pip.
   get_url: url=https://bootstrap.pypa.io/get-pip.py dest={{ pip_download_dest }}


### PR DESCRIPTION
Ansible 2 helpfully explained the situation:

>  [WARNING]: While constructing a mapping from <redacted>/bobbyrenwick.pip/tasks/main.yml,
line 5, column 3, found a duplicate dict key (changed_when).  Using last defined value only.

Snipped out the extra `changed_when` parameter.