### PR TITLE
Replace deprecated "sudo" with "become"

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: bobbyrenwick
   description: An ansible role that ensures pip is installed at the version you specify.
   license: WTFPL
-  min_ansible_version: 1.2
+  min_ansible_version: 1.9
   #
   # Below are all platforms currently available. Just uncomment
   # the ones that apply to your role. If you don't see your

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,7 +15,7 @@
 
 - name: Install pip.
   command: "{{ python }} {{ pip_download_dest }}/get-pip.py"
-  sudo: yes
+  become: yes
   when: pip_is_installed.rc != 0
 
 - name: Delete get-pip.py.
@@ -32,12 +32,12 @@
 
 - name: Install required version of pip.
   command: "{{ pip }} install pip=={{ pip_version }}"
-  sudo: yes
+  become: yes
   when: pip_version != None and pip_installed_version.stdout != pip_version and pip_version != "LATEST"
 
 - name: Upgrade to latest version of pip.
   command: "{{ pip }} install -U pip"
   register: pip_latest_output
-  sudo: yes
+  become: yes
   changed_when: pip_latest_output.stdout.find('Requirement already up-to-date') == -1
   when: pip_version == None or pip_version == "LATEST"


### PR DESCRIPTION
When running this role on ansible 2.0.0.2 it shows deprecation warning "[DEPRECATION WARNING]: instead of sudo/sudo_user, use become/become_user and make sure become_method is 'sudo' (default). This feature will be removed in a future release."

This PR replaces "sudo" with "become"