### PR TITLE
Sets pip lookup command to always run

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,7 +5,8 @@
 - name: Check to see if pip is already installed.
   command: "{{ pip }} --version"
   ignore_errors: true
-  changed_when: false
+  changed_when: false # read-only task
+  always_run: true # for check mode
   register: pip_is_installed
 
 - name: Download pip.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,6 +28,7 @@
   shell: "{{ pip }} --version | awk '{print $2}'"
   register: pip_installed_version
   changed_when: false
+  always_run: true # for check mode
   when: pip_version != None or pip_version != "LATEST"
 
 - name: Install required version of pip.


### PR DESCRIPTION
Since the registered variable is referenced in subsequent tasks, and the
lookup command is read-only, run it even in check mode, otherwise the
role will fail on encountering the undefined registered var.