### PR TITLE
Fix support for managed nodes with py2.6 (centos6)

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,10 @@
 
 pip_download_dest: /tmp
 pip_version:
-python: python
+python: "{{ ansible_python_interpreter | default( ansible_python.executable | default('python') ) }}"
 pip: pip
 pip_proxy: ''
+
+pip_download_url_current: https://bootstrap.pypa.io/get-pip.py
+pip_download_url_py26: https://bootstrap.pypa.io/2.6/get-pip.py
+pip_download_url: "{{ ansible_python.version_info[:3]|join('.') is version_compare('2.7', '>=') | ternary( pip_download_url_current, pip_download_url_py26 ) }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,7 +10,9 @@
   register: pip_is_installed
 
 - name: Download pip.
-  get_url: url=https://bootstrap.pypa.io/get-pip.py dest={{ pip_download_dest }}
+  get_url:
+    url: "{{ pip_download_url }}"
+    dest: "{{ pip_download_dest }}"
   when: pip_is_installed.rc != 0
 
 - name: Install pip.
@@ -19,7 +21,9 @@
   when: pip_is_installed.rc != 0
 
 - name: Delete get-pip.py.
-  file: state=absent path={{ pip_download_dest }}/get-pip.py
+  file:
+    state: absent
+    path: "{{ pip_download_dest }}/get-pip.py"
   when: pip_is_installed.rc != 0
 
 # $ pip --version


### PR DESCRIPTION
The latest versiion of get-pip.py doesn't support Python 2.6 and gives
a SyntaxError when using it. This fixes the URL based on which
version of python ansible is running.

Also updates the python default to use ansible's python interpreter by
default.

Fixes #24