### PR TITLE
Fix version comparison

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -38,7 +38,7 @@
 - name: Install required version of pip.
   command: "{{ pip }} install pip=={{ pip_version }}"
   become: yes
-  when: pip_version and pip_installed_version.stdout != pip_version and (pip_version | lower) != "latest"
+  when: pip_version and pip_installed_version.stdout is version_compare(pip_version, '!=') and (pip_version | lower) != "latest"
 
 - name: Upgrade to latest version of pip.
   command: "{{ pip }} {{ '--proxy=' + pip_proxy + ' ' if pip_proxy != '' else '' }}install -U pip"


### PR DESCRIPTION
The task always run when pip_version is provided with 1 or 2 digits
(eg: 18, 18.0) because it gets converted to number and the comparison was
always true.