### PR TITLE
Fix "'stdout' is undefined" error

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,7 +3,7 @@
 pip_download_dest: /tmp
 pip_version:
 python: "{{ ansible_python_interpreter | default( ansible_python.executable | default('python') ) }}"
-pip: pip
+pip: "{{ ( ansible_python.version_info[0] == 3 ) | ternary('pip3', 'pip') }}"
 pip_proxy: ''
 
 pip_download_url_current: https://bootstrap.pypa.io/get-pip.py

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -46,5 +46,5 @@
   command: "{{ pip }} install -U pip {{ '--proxy=' + pip_proxy if pip_proxy else '' }}"
   register: pip_latest_output
   become: true
-  changed_when: pip_latest_output.stdout.find('Attempting uninstall') != -1
+  changed_when: "'stdout' in pip_latest_output and pip_latest_output.stdout.find('Attempting uninstall') != -1"
   when: not pip_version or (pip_version | lower) == "latest"


### PR DESCRIPTION
This was likely caused by a call to a non-existent pip executable, which
resulted in no standard output being produced. The lack of a test of
existence on 'stdout' masked the actual error.